### PR TITLE
Update reference files for css color tests

### DIFF
--- a/css-color-3/t422-rgba-clamping-a1.0-b-ref.html
+++ b/css-color-3/t422-rgba-clamping-a1.0-b-ref.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Reference</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
+<style>
+  html, body { background: white; }
+</style>
 <body>
   <p>There should be six lines of text on this page, all the same color. [1 of 6]</p>
   <p>There should be six lines of text on this page, all the same color. [2 of 6]</p>

--- a/css-color-3/t424-hsl-basic-a-ref.html
+++ b/css-color-3/t424-hsl-basic-a-ref.html
@@ -3,7 +3,8 @@
 <title>CSS Reference</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <style>
-  p { color: green; }
+  html, body { background: white; }
+  p { color: #008000; }
 </style>
 <body>
   <p>This text should be dark green.</p>

--- a/css-color-3/t424-hsl-parsing-f-ref.html
+++ b/css-color-3/t424-hsl-parsing-f-ref.html
@@ -3,7 +3,8 @@
 <title>CSS Reference</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <style>
-  p { color: green; }
+  html, body { background: white; }
+  p { color: #008000; }
 </style>
 <body>
   <p>This text should be dark green.</p>


### PR DESCRIPTION
- According to color transform website, the render result of hsl(120, 100%, 25%) should be the same as #008000, not green
- Add white background color as origin test setting
